### PR TITLE
Remove redundant "for Emacs" from description line

### DIFF
--- a/download-region.el
+++ b/download-region.el
@@ -1,4 +1,4 @@
-;;; download-region.el --- simple in-buffer download manager for Emacs
+;;; download-region.el --- Simple in-buffer download manager
 
 ;; Copyright (C) 2013 zk_phi
 


### PR DESCRIPTION
We know it's for Emacs. :-)

Re. https://github.com/milkypostman/melpa/pull/1520
