### PR TITLE
Function correctly without transient-mark

### DIFF
--- a/download-region.el
+++ b/download-region.el
@@ -189,7 +189,7 @@
   "download region as url. when a prefix-argument is given,
 download it to the same directory as the last download."
   (interactive "P")
-  (unless (use-region-p) (error "There is no region."))
+  (unless mark-active (error "There is no region."))
   (let* ((beg (region-beginning))
          (end (region-end))
          (url (buffer-substring-no-properties beg end))


### PR DESCRIPTION
Previously, download-region-as-url had tested for
whether-or-not (use-region-p) was t to check for an active region.
Unfortunately, (use-region-p) only ever becomes set if
transient-mark-mode is in use, preventing use of download-region-as-url
for users who do not use transient-mark-mode.

mark-active, on the other hand, becomes t when a region is active
whether-or-not a user is using transient-mark-mode.

Switch to use of mark-active, so that people who do not use
transient-mark-mode can still make use of download-region-as-url.